### PR TITLE
No passlib anymore for OpenSSL pbkdf algorithm.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-passlib == 1.6.5
 pycrypto == 2.6.1
 docopt == 0.6.2
 


### PR DESCRIPTION
Compared to the source code of OpenSSL, it looks
like the original implementation of the password-
based key derivation function was too complex,
and passlib's pbkdf1() is not needed.
